### PR TITLE
Added Unpacker and Packer for Emon Engine.

### DIFF
--- a/ArcFormats/EmonEngine/DECRYPT.cs
+++ b/ArcFormats/EmonEngine/DECRYPT.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace ArcFormats.EmonEngine
+{
+    internal class DECRYPT
+    {
+        internal static unsafe void Decrypt(byte[] buffer, int offset, int length, byte[] routine)
+        {
+            if (null == buffer)
+                throw new ArgumentNullException("buffer", "Buffer cannot be null.");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "Buffer offset should be non-negative.");
+            if (buffer.Length - offset < length)
+                throw new ArgumentException("Buffer offset and length are out of bounds.");
+            fixed (byte* data8 = &buffer[offset])
+            {
+                uint* data32 = (uint*)data8;
+                int length32 = length / 4;
+                int key_index = routine.Length;
+                for (int i = 7; i >= 0; --i)
+                {
+                    key_index -= 4;
+                    uint key = BitConverter.ToUInt32(routine, key_index);
+                    switch (routine[i])
+                    {
+                        case 1:
+                            for (int j = 0; j < length32; ++j)
+                                data32[j] ^= key;
+                            break;
+                        case 2:
+                            for (int j = 0; j < length32; ++j)
+                            {
+                                uint v = data32[j];
+                                data32[j] = v ^ key;
+                                key = v;
+                            }
+                            break;
+                        case 4:
+                            for (int j = 0; j < length32; ++j)
+                                data32[j] = ShiftValue(data32[j], key);
+                            break;
+                        case 8:
+                            InitTable(buffer, offset, length, key);
+                            break;
+                    }
+                }
+            }
+        }
+
+        static uint ShiftValue(uint val, uint key)
+        {
+            int shift = 0;
+            uint result = 0;
+            for (int i = 0; i < 32; ++i)
+            {
+                shift += (int)key;
+                result |= ((val >> i) & 1) << shift;
+            }
+            return result;
+        }
+
+        static void InitTable(byte[] buffer, int offset, int length, uint key)
+        {
+            var table = new byte[length];
+            int x = 0;
+            for (int i = 0; i < length; ++i)
+            {
+                x += (int)key;
+                while (x >= length)
+                    x -= length;
+                table[x] = buffer[offset + i];
+            }
+            Buffer.BlockCopy(table, 0, buffer, offset, length);
+        }
+    }
+}
+

--- a/ArcFormats/EmonEngine/EME.cs
+++ b/ArcFormats/EmonEngine/EME.cs
@@ -1,0 +1,254 @@
+using GalArc.Logs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Utility;
+using Utility.Compression;
+
+namespace ArcFormats.EmonEngine
+{
+    internal class EME
+    {
+        private static readonly string Magic = "RREDATA ";
+
+        public string GetNullTerminatedString(byte[] data, int offset, int maxLength)
+        {
+            int end = Array.IndexOf(data, (byte)0, offset, maxLength);
+            if (end == -1)
+                end = offset + maxLength;
+
+            return ArcEncoding.Shift_JIS.GetString(data, offset, end - offset); //Using sjis just to be safe. Otherwise ascii can do fine as well.
+        }
+        public class Entry
+        {
+            public string Name { get; set; }
+            public uint Offset { get; set; }
+            public uint PackedSize { get; set; }
+            public uint UnpackedSize { get; set; }
+            public int LzssFrameSize { get; set; }
+            public int LzssInitPos { get; set; }
+            public int SubType { get; set; }
+            public bool IsPacked { get; set; }
+        }
+        public void Unpack(string filePath, string folderPath)
+        {
+            FileStream fs = File.OpenRead(filePath);
+            BinaryReader br = new BinaryReader(fs);
+
+            if (Encoding.ASCII.GetString(br.ReadBytes(8)) != Magic)
+            {
+                throw new InvalidDataException("Not a Valid EME Archive");
+            }
+
+            fs.Position = fs.Length - 4;
+            int fileCount = br.ReadInt32();
+
+            if (fileCount < 0 || fileCount > 100000)
+            {
+                throw new InvalidDataException("Invalid File Count");
+            }
+
+            uint indexSize = (uint)fileCount * 0x60;
+            var indexOffset = fs.Length - 4 - indexSize;
+            fs.Position = indexOffset - 40;
+            var key = br.ReadBytes(40);
+
+            fs.Position = indexOffset;
+            var index = br.ReadBytes((int)indexSize);
+
+            int currentOffset = 0;
+            var entries = new List<Entry>(fileCount);
+
+            for (int i = 0; i < fileCount; i++)
+            {
+                Entry entry = new Entry();
+                DECRYPT.Decrypt(index, currentOffset, 0x60, key);
+
+                // Bounds check before reading the name to prevent reading beyond buffer PackedSize
+                if (currentOffset + 0x60 > index.Length)
+                {
+                    throw new InvalidDataException("Index entry exceeds buffer PackedSize.");
+                }
+                entry.Name = GetNullTerminatedString(index, currentOffset, 0x40);
+
+                entry.LzssFrameSize = BitConverter.ToUInt16(index, currentOffset + 0x40);
+                entry.LzssInitPos = BitConverter.ToUInt16(index, currentOffset + 0x42);
+
+                if (entry.LzssFrameSize != 0)
+                    entry.LzssInitPos = (entry.LzssFrameSize - entry.LzssInitPos) % entry.LzssFrameSize;
+
+                entry.SubType = BitConverter.ToUInt16(index, currentOffset + 0x48);  // Adjusted offset for `SubType`
+                entry.PackedSize = BitConverter.ToUInt32(index, currentOffset + 0x4C);
+                entry.UnpackedSize = BitConverter.ToUInt32(index, currentOffset + 0x50);
+                entry.Offset = BitConverter.ToUInt32(index, currentOffset + 0x54);
+                entry.IsPacked = entry.UnpackedSize != entry.PackedSize;
+                entries.Add(entry);
+                currentOffset += 0x60;
+            }
+            foreach (var entry in entries)
+            {
+                Logger.Debug(entry.Name);
+            }
+            Logger.InitBar(fileCount);
+            Directory.CreateDirectory(folderPath);
+
+            foreach (var entry in entries)
+            {
+                fs.Position = entry.Offset;
+                var header = br.ReadBytes(12);
+                DECRYPT.Decrypt(header, 0, 12, key);
+
+                if (0 == entry.LzssFrameSize)
+                {
+                    byte[] data = br.ReadBytes((int)entry.PackedSize);
+                    string fileName = Path.Combine(folderPath, entry.Name);
+                    File.WriteAllBytes(fileName, data);
+                    Logger.UpdateBar();
+                }
+                int part2unpackedSize = BitConverter.ToInt32(header, 4);
+                if (0 != part2unpackedSize && part2unpackedSize < entry.PackedSize)
+                {
+                    uint packedSize = BitConverter.ToUInt32(header, 0);
+                    string fileName = Path.Combine(folderPath, entry.Name);
+                    br.BaseStream.Seek(entry.Offset + 12, SeekOrigin.Begin);
+                    byte[] part2data = br.ReadBytes((int)packedSize);
+                    part2data = Lzss.Decompress(part2data);
+                    br.BaseStream.Seek(entry.Offset + 12 + packedSize, SeekOrigin.Begin);
+                    int part1UnpackedSize = (int)entry.PackedSize;
+                    byte[] part1data = br.ReadBytes(part1UnpackedSize);
+                    part1data = Lzss.Decompress(part1data);
+
+                    //Combine part1data and part2data
+                    byte[] combinedData = new byte[part1data.Length + part2data.Length];
+                    Array.Copy(part1data, 0, combinedData, 0, part1data.Length);
+                    Array.Copy(part2data, 0, combinedData, part1data.Length, part2data.Length);
+
+                    File.WriteAllBytes(fileName, combinedData);
+                }
+
+                else
+                {
+                    fs.Position = entry.Offset + 12;
+                    byte[] data = br.ReadBytes((int)entry.PackedSize);
+                    data = Lzss.Decompress(data);
+                    string fileName = Path.Combine(folderPath, entry.Name);
+                    File.WriteAllBytes(fileName, data);
+                    Logger.UpdateBar();
+                    data = null;
+                }
+            }
+
+            fs.Dispose();
+            br.Dispose();
+        }
+
+        public void Pack(string folderPath, string filePath)
+        {
+            // Track file entries for better organization and accuracy
+            var fileEntries = new List<(
+                string Name,
+                long UnpackedSize,
+                long PackedSize,
+                long Offset,
+                byte[] CompressedData,
+                byte[] HeaderData
+            )>();
+
+            // Get all files and prepare total size estimate
+            FileInfo[] files = new DirectoryInfo(folderPath).GetFiles();
+            Logger.InitBar(files.Length);
+
+            using (FileStream fw = File.OpenWrite(filePath))
+            using (BinaryWriter bw = new BinaryWriter(fw))
+            {
+                // Write file count at the end
+                fw.Position = 0;
+                // Write magic bytes
+                bw.Write(Encoding.ASCII.GetBytes(Magic), 0, Magic.Length);
+                // Start offset after magic bytes
+                long currentOffset = Magic.Length;
+
+                var key = Utils.HexStringToByteArray("0104020800000000f962a8ec11000000f8e296ca0700000000000000000000000000000000000000");
+
+                // First pass: Process and store all file data
+                foreach (FileInfo file in files)
+                {
+                    // Prepare and encrypt header
+                    var header = new byte[12];
+                    BitConverter.GetBytes(0).CopyTo(header, 0);
+                    BitConverter.GetBytes(0).CopyTo(header, 4);
+                    BitConverter.GetBytes(0).CopyTo(header, 8);
+
+                    var encryptedHeader = ENCRYPT.Encrypt(header, 0, header.Length, key);
+                    var finalHeader = ENCRYPT.ApplyHeaderXorMask(encryptedHeader);
+
+                    // Read and compress file data
+                    byte[] originalData = File.ReadAllBytes(file.FullName);
+                    byte[] compressedData = Lzss.Compress(originalData);
+
+                    // Store file information with actual compressed data
+                    fileEntries.Add((
+                        Name: file.Name,
+                        UnpackedSize: originalData.Length,
+                        PackedSize: compressedData.Length,
+                        Offset: currentOffset,
+                        CompressedData: compressedData,
+                        HeaderData: finalHeader
+                    ));
+
+                    // Write header and compressed data
+                    bw.Write(finalHeader);
+                    bw.Write(compressedData);
+
+                    // Update offset for next file
+                    currentOffset += finalHeader.Length + compressedData.Length;
+
+                    Logger.UpdateBar();
+                }
+
+                // Write encryption key
+                bw.Write(key);
+
+                // Write file entries
+                foreach (var entry in fileEntries)
+                {
+                    var ms = new MemoryStream();
+                    var headerWriter = new BinaryWriter(ms);
+                    // File name (padded to 0x40 bytes)
+                    byte[] name = Utils.PaddedBytes(entry.Name, 0x40);
+                    headerWriter.Write(name);
+
+                    // Standard header values
+                    headerWriter.Write((ushort)4096);  // LZSS frame size is same for all.
+                    headerWriter.Write((ushort)18);    // LZSS position is same for all.
+                    headerWriter.Write((uint)1);       // Version flag for script only.
+                    headerWriter.Write((uint)3);       // SubType for Script files.
+
+                    // Size information
+                    headerWriter.Write((uint)entry.PackedSize);  // Original size
+                    headerWriter.Write((uint)entry.UnpackedSize);    // Compressed size
+                    headerWriter.Write((uint)entry.Offset);        // Data offset in file
+
+                    // Reserved fields
+                    headerWriter.Write((uint)0);
+                    headerWriter.Write((uint)0);
+                    byte[] headerBytes = ms.ToArray();
+                    var encryptedHeader = ENCRYPT.Encrypt(headerBytes, 0, headerBytes.Length, key);
+                    var finalHeader = ENCRYPT.ApplyXorMask(encryptedHeader);
+                    bw.Write(finalHeader);
+                    ms.Dispose();
+
+                }
+                bw.Write((uint)0);
+                fw.Position = fw.Length - 4;
+                bw.Write(files.Length);
+                bw.Dispose();
+                fw.Dispose();
+            }
+
+        }
+
+    }
+}
+

--- a/ArcFormats/EmonEngine/ENCRYPT.cs
+++ b/ArcFormats/EmonEngine/ENCRYPT.cs
@@ -1,0 +1,139 @@
+using System;
+using Utility;
+
+namespace ArcFormats.EmonEngine
+{
+    internal class ENCRYPT
+    {
+        public static int ShiftValue(uint result, uint key)
+        {
+            uint originalValue = 0;
+            int shift = 0;
+
+            for (int i = 0; i < 32; i++)
+            {
+                shift += (int)key;
+                int originalPosition = shift % 32;
+                uint bit = (result >> originalPosition) & 1;
+                originalValue |= (bit << i);
+            }
+
+            return (int)originalValue;
+        }
+
+        private static void InitTable(byte[] buffer, uint key)
+        {
+            int length = buffer.Length;
+            byte[] table = new byte[length];
+
+            int[] xSequence = new int[length];
+            int currentX = 0;
+
+            for (int i = 0; i < length; i++)
+            {
+                currentX = (int)((currentX + key) % length);
+                xSequence[i] = currentX;
+            }
+
+            int[] invXSequence = new int[length];
+            for (int i = 0; i < xSequence.Length; i++)
+            {
+                invXSequence[xSequence[i]] = i;
+            }
+
+            for (int i = 0; i < length; i++)
+            {
+                table[invXSequence[i]] = buffer[i];
+            }
+
+            Array.Copy(table, 0, buffer, 0, length);  // Fixed the CopyTo call
+        }
+
+        public static byte[] Encrypt(byte[] buffer, int offset, int length, byte[] routine)
+        {
+            byte[] data = new byte[length];
+            Array.Copy(buffer, offset, data, 0, length);
+
+            for (int i = 0; i < 8; i++)
+            {
+                uint key = BitConverter.ToUInt32(routine, 8 + i * 4);
+
+                switch (routine[i])
+                {
+                    case 1:
+                        for (int j = 0; j < data.Length; j += 4)
+                        {
+                            uint v = BitConverter.ToUInt32(data, j);
+                            BitConverter.GetBytes(v ^ key).CopyTo(data, j);
+                        }
+                        break;
+
+                    case 2:
+                        uint prev = 0;
+                        for (int j = 0; j < data.Length; j += 4)
+                        {
+                            uint v = BitConverter.ToUInt32(data, j);
+                            uint newVal = v ^ key ^ prev;
+                            BitConverter.GetBytes(newVal).CopyTo(data, j);
+                            prev = newVal;
+                        }
+                        break;
+
+                    case 4:
+                        for (int j = 0; j < data.Length; j += 4)
+                        {
+                            uint v = BitConverter.ToUInt32(data, j);
+                            int result = ShiftValue(v, key);
+                            BitConverter.GetBytes(result).CopyTo(data, j);
+                        }
+                        break;
+
+                    case 8:
+                        InitTable(data, key);
+                        break;
+                }
+            }
+
+            return data;
+        }
+
+        public static byte[] ApplyXorMask(byte[] data)
+        {
+            byte[] xorMask = Utils.HexStringToByteArray("ca96e2f800000000");
+            byte[] transformedData = new byte[data.Length];
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                transformedData[i] = (byte)(data[i] ^ xorMask[i % xorMask.Length]);
+            }
+
+            return transformedData;
+        }
+
+        public static byte[] ApplyHeaderXorMask(byte[] data)
+        {
+            byte[] xorMask = Utils.HexStringToByteArray("ca0000f8009600000000e200");
+            byte[] transformedData = new byte[data.Length];
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                transformedData[i] = (byte)(data[i] ^ xorMask[i % xorMask.Length]);
+            }
+
+            return transformedData;
+        }
+
+        public static byte[] ApplyImageHeaderXorMask(byte[] data)
+        {
+            byte[] xorMask = Utils.HexStringToByteArray("ca96e2d0000000a89f96e27800000000cb82e2f800140000ca86c8f800000000");
+            byte[] transformedData = new byte[data.Length];
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                transformedData[i] = (byte)(data[i] ^ xorMask[i % xorMask.Length]);
+            }
+
+            return transformedData;
+        }
+    }
+}

--- a/ArcFormats/GSPack/DAT.cs
+++ b/ArcFormats/GSPack/DAT.cs
@@ -152,11 +152,6 @@ namespace ArcFormats.GSPack
             return ArcEncoding.Shift_JIS.GetString(data, offset, length);
         }
 
-        public void Pack(string folderPath, string outputPath)
-        {
-            FileInfo[] files = new DirectoryInfo(folderPath).GetFiles();
-            Logger.InitBar(files.Length);
-        }
     }
 
 }

--- a/GalArc/Common/EngineInfo.cs
+++ b/GalArc/Common/EngineInfo.cs
@@ -30,6 +30,7 @@ namespace GalArc.Common
             new EngineInfo("Cmvs","CPZ","CPZ"),
             new EngineInfo("EntisGLS","NOA","NOA"),
             new EngineInfo("Eushully","ALF",string.Empty),
+            new EngineInfo("GSPack","DAT",string.Empty),
             new EngineInfo("InnocentGrey","IGA/DAT","IGA/DAT"),
             new EngineInfo("KID","DAT","DAT"),
             new EngineInfo("Kirikiri","XP3","XP3"),


### PR DESCRIPTION
Hey there! So I was working on Emon Engine from a long time and I've successfully made packer and unpacker for all file formats as well Image convertor, but the issue is we need a little metadata to create file that is a 40 byte key that is stored in the file itself and differs for each game engine file. 
To pack script files that is nz_scene.eme we need to change the SubType to 3 and 4 for image file(a custom bmp image).
LzssFrameSize is constant that is 4096, LzssInitPos is 4078(calculated) but initially is (18).

We can ask the user if he/she wants to create a script file archive or a Image archive and set SubType accordingly but if we do not want to use any external metadata file we could use the original file to read the key and use that for file creation.


Let me know how you feel about this so we can approach that way.
(btw I am done with image convertor as well, do have any plans to make GalArc support image conversion as well?)


(NOTE: This is a rough implementation and needs improvement to make it flexible for different scenarios.)